### PR TITLE
CmfCoreBundle:Form:checkbox_url_label_form_type.html.twig not found

### DIFF
--- a/src/DependencyInjection/CmfCoreExtension.php
+++ b/src/DependencyInjection/CmfCoreExtension.php
@@ -295,7 +295,7 @@ class CmfCoreExtension extends Extension implements PrependExtensionInterface
             // if there is twig, register our form type with twig
             if ($container->hasParameter('twig.form.resources')) {
                 $resources = $container->getParameter('twig.form.resources');
-                $container->setParameter('twig.form.resources', array_merge($resources, ['CmfCoreBundle:Form:checkbox_url_label_form_type.html.twig']));
+                $container->setParameter('twig.form.resources', array_merge($resources, ['@CmfCore/Form/checkbox_url_label_form_type.html.twig']));
             }
         }
     }


### PR DESCRIPTION
Template naming reword fixes `Template reference CmfCoreBundle:Form:checkbox_url_label_form_type.html.twig" not found, did you mean "@CmfCore/Form/checkbox_url_label_form_type.html.twig"?` symfony error in Symfony 4.2.3. This error appears when Twig tries to render a form.

| Q             | A
| ------------- | ---
| Branch?       | 2.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a
